### PR TITLE
Add Px-vis-pie-slice-clicked event with tests

### DIFF
--- a/px-vis-pie.html
+++ b/px-vis-pie.html
@@ -350,7 +350,7 @@ Element which draws scatter series onto the chart
         this._arcs.enter()
                   .append('svg:g')
                   .attr('class', 'slice')
-                  .on('tap', this._centerOnSlice.bind(this))
+                  .on('tap', this._onSliceClick.bind(this))
                   .on('mouseover', this._showTooltip.bind(this))
                   .on('mouseleave', this._hideTooltip.bind(this))
                   .append('svg:path')
@@ -444,6 +444,14 @@ Element which draws scatter series onto the chart
           .transition()
           .duration(transitionTime)
           .attr('transform', this._translationString + ' rotate(' + this._radToDeg(this._currentRotationAngle) + ')');
+    },
+    /**
+     * Emits px-vis-pie-slice-clicked event with selected slice data
+     *
+     */
+    _onSliceClick: function (datum, index, group) {
+      this.fire('px-vis-pie-slice-clicked', datum);
+      this._centerOnSlice(datum, index, group);
     },
     /**
      * Transforms the svg to show the slice at the top (12 o clock)

--- a/test/px-vis-pie-tests.js
+++ b/test/px-vis-pie-tests.js
@@ -141,6 +141,31 @@ function runTests(){
       }, 10);
     });
 
+    test('click on slice emits px-vis-pie-slice-clicked event with slice data', function(done) {
+      var slice = basePie.pieGroup._groups[0][0].firstChild,
+        evt = document.createEvent("MouseEvent"),
+        sliceName = slice.__data__.data.y,
+        sliceAmount = slice.__data__.data.x,
+        slicePercentage = slice.__data__.data.percentage;
+
+      evt.initMouseEvent("tap",true,true,window,0,0,0,0,0,false,false,false,false,0,null);
+      basePie.addEventListener('px-vis-pie-slice-clicked', function (e) {
+        var eventSliceName = e.detail.data.y,
+            eventSliceAmount = e.detail.data.x,
+            eventSlicePercentage = e.detail.data.percentage;
+        assert.equal(sliceName, eventSliceName);
+        assert.equal(sliceAmount, eventSliceAmount);
+        assert.equal(slicePercentage, eventSlicePercentage);
+      });
+      //click
+      slice.dispatchEvent(evt);
+
+      setTimeout(function() {
+
+        done();
+      }, 100);
+    });
+
   }); //suite
 
 


### PR DESCRIPTION
# Pull Request

Hi,

Thanks for helping us improve the Predix UI platform by submitting a Pull Request.

To help us merge your Pull Request as fast as possible, please fill out the following sections:

* ## A description of the changes proposed in the pull request:
When a user clicks a slice of the pie, it fires a px-vis-pie-slice-clicked event with the slice data.

* ## A reference to a related issue (if applicable):
https://github.com/PredixDev/px-vis-pie-chart/issues/14

* ## @mentions of the person or team responsible for reviewing proposed changes:
@benoitjchevalier 

* ## working tests:
#### The tests need to be functional and/or unit tests, written for the wct framework, and placed in the test folder, following our testing guidelines.
