### PR TITLE
Fix for line should be able to be started off muted #30

### DIFF
--- a/demos/px-vis-line-demo.html
+++ b/demos/px-vis-line-demo.html
@@ -40,6 +40,7 @@
           chart-data="[[chartData]]"
           x="[[x]]"
           y="[[y]]"
+          muted-series="[[mutedSeries]]"
           domain-changed="[[domainChanged]]">
         </px-vis-line>
 
@@ -133,6 +134,12 @@
               "y": 'y',
               'color': "rgb(93,165,218)"
             }
+          }
+        },
+        mutedSeries: {
+          type: Object,
+          value : {
+            "mySeries": false
           }
         },
         //chartExtents

--- a/px-vis-line.html
+++ b/px-vis-line.html
@@ -128,7 +128,8 @@ Element which draws lines series onto the chart
        * This property will be read from the completeSeriesConfig
        */
       mutedOpacity: {
-        type: Number
+        type: Number,
+        value: 0
       }
     },
 
@@ -241,8 +242,12 @@ Element which draws lines series onto the chart
         }.bind(this));
         this._colorLine();
       } else if(this.mutedSeries.hasOwnProperty(this.seriesId)){
-
-        this._colorLine();
+        if (this.mutedSeries[this.seriesId]){
+          console.log(this.mutedSeries[this.seriesId])
+          this._muteLine();
+        } else {
+          this._colorLine();
+        }
       }
     },
     /**
@@ -250,35 +255,44 @@ Element which draws lines series onto the chart
      *
      */
     _colorLine:function(){
-      this.linePath.attr('stroke',function(d,i){
-        //normally, do this
-        if(!this.categoryKey){
-          return this.completeSeriesConfig[this.seriesId]['color'];
-        }
+      if (this.linePath){
+        this.linePath.attr('stroke',function(d,i){
+          //normally, do this
+          if(!this.categoryKey){
+            return this.completeSeriesConfig[this.seriesId]['color'];
+          }
 
-        //check that category has been defined
-        if(this.completeSeriesConfig[d[this.categoryKey]]){
-          return this.completeSeriesConfig[d[this.categoryKey]]['color']
-        }
+          //check that category has been defined
+          if(this.completeSeriesConfig[d[this.categoryKey]]){
+            return this.completeSeriesConfig[d[this.categoryKey]]['color']
+          }
 
-        //do nothing if not
-        return
-      }.bind(this))
-      .attr('stroke-opacity',this._svgLineOpacity.bind(this));
+          //do nothing if not
+          return
+        }.bind(this))
+          .attr('stroke-opacity',this._svgLineOpacity.bind(this));
+      }
     },
     /**
      * Returns the opacity for the SVG line
      *
      */
-    _svgLineOpacity: function(d) {
-      if(this.mutedSeries[this.seriesId]) {
+    _svgLineOpacity: function (d) {
+      if (this.mutedSeries[this.seriesId]) {
         return this.mutedOpacity;
       }
-      if(this.gradientLine) {
+      if (this.gradientLine) {
         return this._opacityLine(d);
       } else {
         return 1;
       }
+    },
+    /*
+    * mute the serie with mutedOpacity 0 and stroke width 0
+     */
+    _muteLine: function () {
+      if (this.linePath) this.linePath.attr('stroke', this.completeSeriesConfig[this.seriesId]['color'])
+        .attr('stroke-opacity', this.mutedOpacity).attr('stroke-width' , 0);
     }
   });
 </script>


### PR DESCRIPTION
# Pull Request

Hi,

Thanks for helping us improve the Predix UI platform by submitting a Pull Request.

To help us merge your Pull Request as fast as possible, please fill out the following sections:

* ## A description of the changes proposed in the pull request:
when there is mutedseries is there, the line should be muted (not visible), I used stoke-opacity and stroke-width with the value 0 to achieve it. The same can be done with the display property to be set to none.

* ## A reference to a related issue (if applicable):

* ## @mentions of the person or team responsible for reviewing proposed changes:

* ## working tests:
Tested manually by adding the mutedSeries to the px-vis-line-demo.html

#### The tests need to be functional and/or unit tests, written for the wct framework, and placed in the test folder, following our testing guidelines.
