### PR TITLE
fixing an issue

### DIFF
--- a/px-vis-axis.html
+++ b/px-vis-axis.html
@@ -145,7 +145,7 @@ https://github.com/mbostock/d3/wiki/SVG-Axes
            * Boolean to specify not to draw the series bars
            */
           preventSeriesBar: {
-            type: Boolean,
+            type: Object,
             value: false
           },
           /**


### PR DESCRIPTION
In Polymer, if a property is defined as Boolean, then presence of that property in markup will lead to be treated as value true even if value is false, e.g.
`<px-vis-axis id="xaxis" prevent-series-bar="false"></px-vis-axis> will still consider it as true.`

This happens for same reason, if("false") console.log("true") will be logging "true" on console.

More details can be found here.
https://github.com/Polymer/polymer/issues/1812

one of solution, which I think is minimum impact silver bullet, is to have such properties defined as Object rather than Boolean.

I have made this change for preventSeriesBar for px-vis-axis, as we use that in px-vis-xy-chart and our use case only has one series so not having series bar on y axis would be nice. 

I hope this helps

Sandeep Khandewale
(Consultant, GE Oil and Gas, Mumbai)