### PR TITLE
fix incorrect polymer annotations

### DIFF
--- a/px-vis-behavior-common.html
+++ b/px-vis-behavior-common.html
@@ -42,7 +42,7 @@ PxVisBehavior.baseSize = {
     PxVisBehavior.baseSize
 
     Description:
-    Polymer behavior that provides height and width
+    Polymer behavior that provides margin definitions
 
     @polymerBehavior PxVisBehavior.margins
 */

--- a/px-vis-behavior-common.html
+++ b/px-vis-behavior-common.html
@@ -44,7 +44,7 @@ PxVisBehavior.baseSize = {
     Description:
     Polymer behavior that provides height and width
 
-    @polymerBehavior PxVisBehavior.baseSize
+    @polymerBehavior PxVisBehavior.margins
 */
 PxVisBehavior.margins = {
 
@@ -1321,7 +1321,7 @@ PxVisBehavior.tooltipOnHover = {
     Dependencies:
     - D3.js
 
-    @polymerBehavior PxVisBehaviorD3.polarData
+    @polymerBehavior PxVisBehavior.polarData
 */
 PxVisBehavior.polarData = {
   properties: {

--- a/px-vis-behavior-d3.html
+++ b/px-vis-behavior-d3.html
@@ -243,7 +243,7 @@ PxVisBehaviorD3.svg = [{
     Dependencies:
     - D3.js
 
-    @polymerBehavior PxVisBehaviorD3.svg
+    @polymerBehavior PxVisBehaviorD3.svgLower
 */
 PxVisBehaviorD3.svgLower = [{
   properties: {

--- a/px-vis-behavior-register.html
+++ b/px-vis-behavior-register.html
@@ -1,3 +1,5 @@
+<link rel="import" href="px-vis-behavior-common.html">
+
 <script>
 var PxVisBehaviorRegister = PxVisBehaviorRegister || {};
 

--- a/px-vis-chart-navigator.html
+++ b/px-vis-chart-navigator.html
@@ -164,8 +164,7 @@ Provides an interactive chart navigator with a brush to adjust the chart domain
           PxVisBehaviorChart.axisConfigs,
           PxVisBehaviorChart.subConfiguration,
           PxVisBehaviorChart.layers,
-          PxColorsBehavior.dataVisColorTheming,
-          commonColors
+          PxColorsBehavior.dataVisColorTheming
         ],
 
         /**


### PR DESCRIPTION
(https://github.com/PredixDev/px-vis/issues/70)

This PR fixes some polymer behavior annotations that prevent the px-vis-timeseries component to be used with [polymer-build](https://github.com/Polymer/polymer-build).

This should fix: https://github.com/PredixDev/px-vis/issues/70

@nonmetalhail please review