### PR TITLE
default to system timezone instead of UTC in behavior datatime

### DIFF
--- a/px-vis-behavior-datetime.html
+++ b/px-vis-behavior-datetime.html
@@ -76,7 +76,7 @@ PxVisBehaviorTime.datetime = {
      */
     timezone:{
       type:String,
-      value:Px.moment.tz.guess() || 'utc'
+      value:'utc'
     },
   },
   /**

--- a/px-vis-behavior-datetime.html
+++ b/px-vis-behavior-datetime.html
@@ -64,7 +64,7 @@ PxVisBehaviorTime.datetime = {
     /**
      * Sets what timezone the event time should display in.
      *
-     * Timezone defaults to UTC time. If a valid timezone is specified, then times include daylight savings time if applicable.
+     * Defaults to the system timezone or uses UTC if it can't be determined. If a valid timezone is specified, then times include daylight savings time if applicable.
      *
      * For a list of valid timezones, see: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
      *
@@ -72,11 +72,11 @@ PxVisBehaviorTime.datetime = {
      *
      * @property timezone
      * @type String
-     * @default utc
+     * @default system timezone
      */
     timezone:{
       type:String,
-      value:"utc"
+      value:Px.moment.tz.guess() || 'utc'
     },
   },
   /**


### PR DESCRIPTION
Changes the default timezone value from 'utc' to the local timezone in px-vis-behavior-datetime.html.  UTC will be used only if a local timezone can't be determined.

