### PR TITLE
- allow the interpolation of individual series' via the <px-vis-data-converter>

### DIFF
--- a/px-vis-behavior-chart.html
+++ b/px-vis-behavior-chart.html
@@ -178,7 +178,7 @@ PxVisBehaviorChart.chartCommon = [{
       if(this._doesObjHaveValues(this._defaultSeriesConfig) && this._doesObjHaveValues(this.chartData) && this._doesObjHaveValues(this.dataVisColors) && this.dataVisColors['pxVisSeriesColor0']) {
         // FUTURE TODO refactor: use MAPs and SETs instead of Objects when IE has support / is no longer supported by us
         // We could use d3 sets and maps... worth it?
-        var fullConfig = (this.seriesConfig) ? this.seriesConfig : {},
+        var fullConfig = (this.seriesConfig) ? this.clone(this.seriesConfig) : {},
             k = Object.keys(fullConfig),
             kLen = k.length,
             allYs = (this.includeAllSeries) ? this._returnAllKeys(this.chartData) : [],

--- a/px-vis-behavior-chart.html
+++ b/px-vis-behavior-chart.html
@@ -178,7 +178,7 @@ PxVisBehaviorChart.chartCommon = [{
       if(this._doesObjHaveValues(this._defaultSeriesConfig) && this._doesObjHaveValues(this.chartData) && this._doesObjHaveValues(this.dataVisColors) && this.dataVisColors['pxVisSeriesColor0']) {
         // FUTURE TODO refactor: use MAPs and SETs instead of Objects when IE has support / is no longer supported by us
         // We could use d3 sets and maps... worth it?
-        var fullConfig = (this.seriesConfig) ? JSON.parse(JSON.stringify(this.seriesConfig)) : {},
+        var fullConfig = (this.seriesConfig) ? this.seriesConfig : {},
             k = Object.keys(fullConfig),
             kLen = k.length,
             allYs = (this.includeAllSeries) ? this._returnAllKeys(this.chartData) : [],

--- a/px-vis-behavior-common.html
+++ b/px-vis-behavior-common.html
@@ -737,7 +737,25 @@ PxVisBehavior.commonMethods = {
       return result ? 'rgb(' + parseInt(result[1], 16) + ',' +
                                parseInt(result[2], 16)+ ',' +
                                parseInt(result[3], 16) + ')' : null;
-  }
+  },
+
+  /**
+   * deep-copy object
+  */
+  clone: function(object, newObject) {
+    var newObject = newObject || {};
+    for (i in object) {
+      if (object.hasOwnProperty(i)) {
+        if (typeof object[i] === 'object') {
+          newObject[i] = Array.isArray(object[i]) ? [] : {};
+          this.clone(object[i], newObject[i])
+        } else {
+          newObject[i] = object[i];
+        }
+      }
+    } 
+    return newObject;
+  } 
 };
 
 /*
@@ -1891,7 +1909,6 @@ PxVisBehavior.selectionType = {
 
 /*
     Name:
-<<<<<<< HEAD
     PxVisBehavior.measureText
 
     Description:

--- a/px-vis-data-converter.html
+++ b/px-vis-data-converter.html
@@ -334,6 +334,10 @@ It will reformat the data into the object format and create a seriesConfig file.
           if(this.originalData[i]['axis']){
             seriesConfig[id]['axis'] = this.originalData[i]['axis'];
           }
+
+          if(this.originalData[i]['interpolationFunction']) {
+            seriesConfig[id]['interpolationFunction'] = this.originalData[i]['interpolationFunction'];
+          }
         }
 
         this.fire('px-vis-series-config', { 'dataVar': 'seriesConfig', 'data': seriesConfig, 'method':'set' });

--- a/test/px-vis-behavior-chart-fixture.html
+++ b/test/px-vis-behavior-chart-fixture.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Web Component Test : Fixture to test px-vis-behavior-chart</title>
+
+    <!-- Requires Webcomponents.js polyfill is provided by the page for browsers that don't support html imports -->
+    <script src="../bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
+    <!-- web-component-tester automatically provides local copy of brower.js below
+         for any URL ending with "/web-component-tester/browser.js"
+         when wct is run from the command line -->
+    <script src="../web-component-tester/browser.js"></script>
+    <!-- Retain this link for px-theme.html -->
+    <link rel="import" href="../px-vis-behavior-chart.html" />
+    <link rel="import" href="../px-colors-design/colors.html" />
+    <!-- px-theme is needed for WCT to run without errors -->
+    <link rel="import" href="../../px-theme/px-theme-styles.html">
+    <style include="px-theme-styles" is="custom-style"></style>
+
+    <script src="px-vis-behavior-chart-tests.js"></script>
+  </head>
+
+  <body>
+    <h3>Web Component Test : Fixture for px-vis-behavior-chart</h3>
+
+    <script>
+      Polymer({
+        is: 'test-component',
+        behaviors: [ PxColorsBehavior.dataVisColorTheming, PxVisBehaviorChart.chartCommon ]
+      })
+    </script>
+
+    <template is="dom-bind">
+      <test-component></test-component>
+    </template>
+  </body>
+</html>

--- a/test/px-vis-behavior-chart-tests.js
+++ b/test/px-vis-behavior-chart-tests.js
@@ -1,0 +1,56 @@
+document.addEventListener("WebComponentsReady", function() {
+  runTests();
+});
+
+function runTests(){
+  suite('px-vis-behavior-chart does Polymer exist?', function() {
+    test('Polymer exists', function() {
+      assert.isTrue(Polymer !== null);
+    });
+  });
+
+  suite('px-vis-behavior-chart completeSeriesconfig test', function() {
+    var testComponent = document.querySelector('test-component'),
+      seriesConfig = {},
+      chartData = [{x: 'time', y: 'myTest'}];
+
+    suiteSetup(function(done) {
+      seriesConfig = {
+        'My Series': {
+          'name': 'My Series',  //human readable name
+          'x': 'x',
+          'y': 'y',
+          'interpolationFunction': function() {},
+          'axis': {
+            'id': 'AXIS_ID',
+            'side': 'left',
+            'number': 1
+          }
+        }
+      };
+
+      testComponent.set('chartData', chartData)
+      testComponent.set('seriesConfig', seriesConfig);
+
+      setTimeout(function() {
+        done();
+      }, 300);
+    });
+
+    test('CompleteSeriesConfig is created', function() {
+      assert.isDefined(testComponent.completeSeriesConfig);
+    });
+
+    test('CompleteSeriesConfig is new object', function() {
+      assert.notStrictEqual(testComponent.completeSeriesConfig, seriesConfig);
+    });
+
+    test('CompleteSeriesConfig contains seriesConfig members', function() {
+      assert.strictEqual(testComponent.completeSeriesConfig['My Series']['name'], seriesConfig['My Series']['name']);
+      assert.strictEqual(testComponent.completeSeriesConfig['My Series']['x'], seriesConfig['My Series']['x']);
+      assert.strictEqual(testComponent.completeSeriesConfig['My Series']['y'], seriesConfig['My Series']['y']);
+      assert.strictEqual(testComponent.completeSeriesConfig['My Series']['interpolationFunction'], seriesConfig['My Series']['interpolationFunction']);
+      assert.deepEqual(testComponent.completeSeriesConfig['My Series']['axis'], seriesConfig['My Series']['axis']);
+    });
+  });
+}

--- a/test/px-vis-data-converter-tests.js
+++ b/test/px-vis-data-converter-tests.js
@@ -170,7 +170,8 @@ function runTests(){
           [1397219100000, 6]
         ],
         "tag": "myTest",
-        "title": "My Test"
+        "title": "My Test",
+        "interpolationFunction": "curveStepAfter"
       }];
 
       singleConverterOptions.set('originalData',d);
@@ -210,13 +211,14 @@ function runTests(){
 
       test('singleConverterOptions seriesConfig has correct keys', function() {
         var keys = Object.keys(singleConverterOptions.seriesConfig['myTest'])
-        assert.deepEqual(keys, ['name','x','y']);
+        assert.deepEqual(keys, ['name','x','y', 'interpolationFunction']);
       });
 
       test('singleConverterOptions seriesConfig has correct values', function() {
         assert.equal(singleConverterOptions.seriesConfig['myTest']['name'], 'My Test');
         assert.equal(singleConverterOptions.seriesConfig['myTest']['x'], 'time');
         assert.equal(singleConverterOptions.seriesConfig['myTest']['y'], 'myTest');
+        assert.equal(singleConverterOptions.seriesConfig['myTest']['interpolationFunction'], 'curveStepAfter');
       });
     });
   });


### PR DESCRIPTION
* ## A description of the changes proposed in the pull request:

This PR allows the _interpolation by series_ feature (added in v1.1.0) to be used in conjunction with the `<px-vis-data-converter>`.

* ## A reference to a related issue (if applicable):

https://github.com/PredixDev/px-vis-timeseries/issues/40

* ## @mentions of the person or team responsible for reviewing proposed changes:

@nonmetalhail 

* ## working tests:

_test/px-vis-data-converter-tests.js_

