### PR TITLE
update actionable dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -37,7 +37,7 @@
     "px-code-design": "^1.1.5",
     "px-meta-buttons-design": "^0.6.4",
     "px-layout-design": "^0.4.4",
-    "px-actionable-text-icons-design": "^1.1.5",
+    "px-actionable-design": "^1.1.5",
     "px-demo-data": "^0.0.20",
     "iron-ajax": "PolymerElements/iron-ajax#^1.4.3"
   }

--- a/sass/px-vis-overview.scss
+++ b/sass/px-vis-overview.scss
@@ -53,7 +53,7 @@ $inuit-enable-code--inline : true;
 
 // Objects
 $actionable : true;
-@import "px-actionable-text-icons-design/_objects.actionable.scss";
+@import "px-actionable-design/_objects.actionable.scss";
 
 
 $inuit-enable-list-inline--delimited : true;

--- a/sass/px-vis-summary-demo.scss
+++ b/sass/px-vis-summary-demo.scss
@@ -39,7 +39,7 @@ $inuit-enable-code--inline : true;
 
 // Objects
 $actionable : true;
-@import "px-actionable-text-icons-design/_objects.actionable.scss";
+@import "px-actionable-design/_objects.actionable.scss";
 
 $inuit-enable-inline-fields : true;
 $inuit-enable-input--regular : true;


### PR DESCRIPTION
Updated bower.json and sass files to reflect repo name change from `px-actionable-text-icons-design` to `px-actionable-design`