### PR TITLE
Issue #96 Error when height width not specified.

### DIFF
--- a/px-vis-behavior-common.html
+++ b/px-vis-behavior-common.html
@@ -1993,7 +1993,7 @@ PxVisBehavior.uniqueIds = {
       for(var i=0; i<this._uniqueIdsUsed.length; i++) {
         Px.uniqueIds.splice(Px.uniqueIds.indexOf(this._uniqueIdsUsed[i]), 1);
       }
-      this._uniqueIdsUsed = null;
+      this._uniqueIdsUsed = [];
     }
   },
   /**


### PR DESCRIPTION
This is a possible workaround for issue #96 .

In essence we are seeing an exception thrown when using px-vis-timeseries without specifying height/width.
It seems the px-clip-path.html `_drawElement()` method is trying to use a behavior method `generateRandomID()` after that behavior has previously `detached()`.

